### PR TITLE
Added .tsx to use TypeScript icon for react.

### DIFF
--- a/styles/atom-file-icons.less
+++ b/styles/atom-file-icons.less
@@ -248,6 +248,7 @@
 		.file-icon(twig);
 	}
 
+	[data-name$=".tsx"]:before,
 	[data-name$=".ts"]:before {
 		.file-icon(typescript);
 	}
@@ -511,7 +512,7 @@
 	[data-name$=".hxx"]:before {
 		.file-icon(cpp);
 	}
-	
+
 }
 
 .tree-view {


### PR DESCRIPTION
In react/typescript projects using `.tsx` file extension, it does not use the TypeScript icon. A one line change fixes this. Love the atom package. It's one of my favs aside from this one little thing.